### PR TITLE
don't run wifi on boot

### DIFF
--- a/scripts/init-norns.sh
+++ b/scripts/init-norns.sh
@@ -58,5 +58,6 @@ echo "both" > /sys/class/gpio/gpio39/edge
 # start norns
 su pi -c "cd /home/pi/norns; ./start.sh;"
 
-# start network
-/home/pi/norns-image/scripts/wifi.sh hotspot
+# clean up stale wifi status from shutdown
+echo stopped > $HOME/status.wifi
+


### PR DESCRIPTION
this should bring up OLED UI with correct info on wifi state. (and obviously boot by default into wifi off)

Will be able to test a bit later on, but think it'll just work!