### PR TITLE
Add M-Audio MidiSport firmware package

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 # install needed packages
-sudo apt install hostapd
+sudo apt install hostapd midisport-firmware
 
 # setup
 sudo cp config/cmdline.txt /boot/


### PR DESCRIPTION
Required to make the in-kernel support for M-Audio MidiSport devices work

These are the only USB MIDI devices supported by the kernel that need additional firmware, since we enabled all USB MIDI devices in the kernel it makes sense to make sure the required firmware is available as well