### PR TITLE
setup: hold updating of kernel

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,6 @@
+# hold packages we don't want to update
+echo "raspberrypi-kernel hold" | sudo dpkg --set-selections
+
 # install needed packages
 sudo apt install hostapd midisport-firmware
 


### PR DESCRIPTION
To prevent the upstream raspberry kernel from overwriting our own kernel

Result
```
$ sudo apt-get update && sudo apt-get upgrade
...
The following packages have been kept back:
  raspberrypi-kernel
```