### PR TITLE
new update script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -25,7 +25,7 @@ if [ ! -f "$disk_mount" ]; then
 fi
 
 # CHECK FOR LOCAL UPDATE FILES
-local_update=$(ls /home/we/update | grep norns | sed 's/.norns//' | sort -r | head -1)
+local_update=$(ls /home/we/update | grep '\.norns$' | sed 's/.norns//' | sort -r | head -1)
 echo "LOCAL UPDATE VERSION: $local_update"
 if [ -z "$local_update" ]; then
   echo "error > NO UPDATES"

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# CHECK DISK FREE SPACE
+required_disk_free=200000
+disk_free=$(df -l | grep '/dev/root' | awk '{print $4}')
+echo "FREE DISK SPACE: $disk_free M"
+if [ "$disk_free" -lt "$required_disk_free" ]; then
+  echo "error > NOT ENOUGH FREE DISK SPACE"
+  exit
+fi
+
+# GET CURRENT VERSION
+version=$(cat /home/we/version.txt)
+echo "CURRENT VERSION: $version"
+
+# CHECK FOR USB DISK UPDATE FILES, COPY IF VALID
+disk_mount=$(lsblk -o mountpoint | grep media)
+if [ ! -f "$disk_mount" ]; then
+  echo "USB DISK PRESENT"
+  from_disk=$(ls $disk_mount | grep norns | sed 's/.norns//' | sort -r | head -1)
+  if [ "$from_disk" -gt "$version" ]; then
+    echo "> COPYING FROM USB DISK"
+    sudo cp -v $disk_mount/$from_disk.norns /home/we/update/
+  fi
+fi
+
+# CHECK FOR LOCAL UPDATE FILES
+local_update=$(ls /home/we/update | grep norns | sed 's/.norns//' | sort -r | head -1)
+echo "LOCAL UPDATE VERSION: $local_update"
+if [ -z "$local_update" ]; then
+  echo "error > NO UPDATES"
+  exit
+fi
+if [ "$version" -gt "$local_update" ]; then
+  echo "error > OLD UPDATE, NOT APPLYING"
+  echo "> REMOVING UPDATES"
+  rm -rf /home/we/update/*
+fi
+
+# EXTRACT UPDATE
+echo "> EXTRACTING UPDATE $local_update"
+cd /home/we/update
+tar xzvf $local_update.norns
+
+# CHECK MD5
+check=$(md5sum -c *.md5 | grep "OK")
+if [ -z "$check" ]; then
+  echo ">>>> MD5 FAILED. BAD UPDATE FILE."
+  exit
+fi
+
+# RUN UPDATE
+tar xzvf $local_update.tgz
+echo "--------------------"
+echo "> RUNNING $local_update/update.sh"
+$local_update/update.sh
+
+echo "--------------------"
+echo "UPDATE COMPLETE"
+
+# CLEANUP
+echo "> REMOVING UPDATES"
+rm -rf /home/we/update/*
+
+# REBOOT
+read -p "PRESS ENTER TO SHUTDOWN"
+echo "SHUTTING DOWN"
+sudo shutdown now

--- a/update.sh
+++ b/update.sh
@@ -5,7 +5,7 @@ required_disk_free=200000
 disk_free=$(df -l | grep '/dev/root' | awk '{print $4}')
 echo "FREE DISK SPACE: $disk_free M"
 if [ "$disk_free" -lt "$required_disk_free" ]; then
-  echo "error > NOT ENOUGH FREE DISK SPACE"
+  echo "error > NOT ENOUGH FREE DISK SPACE (200M REQUIRED)"
   exit
 fi
 
@@ -35,6 +35,7 @@ if [ "$version" -gt "$local_update" ]; then
   echo "error > OLD UPDATE, NOT APPLYING"
   echo "> REMOVING UPDATES"
   rm -rf /home/we/update/*
+  exit
 fi
 
 # EXTRACT UPDATE
@@ -45,7 +46,7 @@ tar xzvf $local_update.norns
 # CHECK MD5
 check=$(md5sum -c *.md5 | grep "OK")
 if [ -z "$check" ]; then
-  echo ">>>> MD5 FAILED. BAD UPDATE FILE."
+  echo "error > MD5 FAILED. BAD UPDATE FILE."
   echo "> REMOVING UPDATES"
   rm -rf /home/we/update/*
   exit

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 
 # CHECK DISK FREE SPACE
 required_disk_free=200000

--- a/update.sh
+++ b/update.sh
@@ -46,6 +46,8 @@ tar xzvf $local_update.norns
 check=$(md5sum -c *.md5 | grep "OK")
 if [ -z "$check" ]; then
   echo ">>>> MD5 FAILED. BAD UPDATE FILE."
+  echo "> REMOVING UPDATES"
+  rm -rf /home/we/update/*
   exit
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -17,7 +17,7 @@ echo "CURRENT VERSION: $version"
 disk_mount=$(lsblk -o mountpoint | grep media)
 if [ ! -f "$disk_mount" ]; then
   echo "USB DISK PRESENT"
-  from_disk=$(ls $disk_mount | grep norns | sed 's/.norns//' | sort -r | head -1)
+  from_disk=$(ls $disk_mount | grep '\.norns$' | sed 's/.norns//' | sort -r | head -1)
   if [ "$from_disk" -gt "$version" ]; then
     echo "> COPYING FROM USB DISK"
     sudo cp -v $disk_mount/$from_disk.norns /home/we/update/

--- a/update.sh
+++ b/update.sh
@@ -65,7 +65,7 @@ echo "UPDATE COMPLETE"
 echo "> REMOVING UPDATES"
 rm -rf /home/we/update/*
 
-# REBOOT
+# REBOOT (after updating update.sh)
 read -p "PRESS ENTER TO SHUTDOWN"
 echo "SHUTTING DOWN"
-sudo shutdown now
+sudo cp /home/we/norns-image/update.sh /home/we/ ; sudo shutdown now


### PR DESCRIPTION
new update method attached. forthcoming edits to norns menu lua code.

here's the new method, which will allow for more error reporting and understanding of what's going on.

- update files have a custom extension (so browsers won't auto-extract) ie `181101.norns`
- user puts update file in `~/update/` via SFTP or
- user can put file on USB drive root
- user manually runs this update file by logging in via SSH or serial:

```
./update.sh
```

- checks free disk space (point of failure earlier)
- checks versions and only copies/performs when appropriate
- cleans up (deletes all update files) afterwards