### PR TITLE
add delay

### DIFF
--- a/config/norns-jack.service
+++ b/config/norns-jack.service
@@ -10,6 +10,7 @@ Environment="JACK_NO_AUDIO_RESERVATION=1"
 LimitRTPRIO=95
 LimitMEMLOCK=infinity
 ExecStart=/usr/bin/jackd -R -P 95 -d alsa -d hw:0 -r 48000 -n 3 -p 128 -S -s
+ExecStartPost=/bin/sleep 2
 TimeoutStopSec=1
 
 [Install]


### PR DESCRIPTION
this appears to fix intermittent audio engine error / jack startup issues

`JACK_NO_START_SERVER=1` env var should ideally also be set 