### PR TITLE
networkmanager: disable audit (logs)

### DIFF
--- a/config/network-manager/101-logging.conf
+++ b/config/network-manager/101-logging.conf
@@ -1,0 +1,3 @@
+[logging]
+audit=false
+domains=DEFAULT:INFO,AUDIT:OFF

--- a/setup.sh
+++ b/setup.sh
@@ -41,9 +41,11 @@ sudo cp config/bashrc /home/we/.bashrc
 # Use the upstream rtl8192cu driver instead of the problematic realtek 8192cu driver
 sudo rm -f /etc/modprobe.d/blacklist-rtl8192cu.conf
 sudo cp config/blacklist-8192cu.conf /etc/modprobe.d/
+# NetworkManager config
 sudo cp config/interfaces /etc/network/interfaces
 sudo cp config/network-manager/HOTSPOT /etc/NetworkManager/system-connections/
 sudo cp config/network-manager/100-disable-wifi-mac-randomization.conf /etc/NetworkManager/conf.d/
+sudo cp config/network-manager/101-logging.conf /etc/NetworkManager/conf.d/
 sudo cp config/network-manager/200-disable-nmcli-auth.conf /etc/NetworkManager/conf.d/
 sudo systemctl disable pppd-dns.service
 


### PR DESCRIPTION
We don't need the audit trail, nor the logs, so disable auditd integration and turn off
the audit logs. The logs are just noise and the auditd integration resulted in errors
because we aren't running auditd

Rather insignificant change, but I got annoyed by the errors in the logs when testing the wifi :stuck_out_tongue: 