### PR TITLE
Remove plymouth

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -56,10 +56,12 @@ sudo cp config/rsyslog.conf /etc/
 sudo cp config/rsyslog /etc/rsyslog.d/
 
 # Plymouth
-sudo systemctl mask plymouth-read-write.service
-sudo systemctl mask plymouth-start.service
-sudo systemctl mask plymouth-quit.service
-sudo systemctl mask plymouth-quit-wait.service
+# Get rid of our old masked plymouth units
+sudo systemctl unmask plymouth-read-write.service
+sudo systemctl unmask plymouth-start.service
+sudo systemctl unmask plymouth-quit.service
+sudo systemctl unmask plymouth-quit-wait.service
+sudo apt-get purge -y plymouth
 
 # Apt timers
 sudo systemctl mask apt-daily.timer


### PR DESCRIPTION
Turns out we can just uninstall it, no need to keep it and mask it's units.

Because we've masked the plymouth units so far (i.e. symlinked them to `/dev/null`) when uninstalling the plymouth package these masked units remain, which isn't very clean so I've added the unmask commands to revert that. These commands do nothing if the unit is already unmasked (as is the case in a plain raspbian install).