### PR TITLE
Install/update raspberry firmware files using a specific version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ do
 done
 
 # uninstall old network packages
-sudo apt-get purge -y hostapd
+sudo apt purge hostapd
 
 # install needed packages
 #sudo apt install network-manager dnsmasq-base midisport-firmware
@@ -72,7 +72,7 @@ sudo systemctl unmask plymouth-read-write.service
 sudo systemctl unmask plymouth-start.service
 sudo systemctl unmask plymouth-quit.service
 sudo systemctl unmask plymouth-quit-wait.service
-sudo apt-get purge -y plymouth
+sudo apt purge plymouth
 
 # Apt timers
 sudo systemctl mask apt-daily.timer

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,21 @@ sudo cp config/norns.list /etc/apt/sources.list.d/
 # hold packages we don't want to update
 echo "raspberrypi-kernel hold" | sudo dpkg --set-selections
 
+# uninstall packages we don't need
+sudo apt purge libraspberrypi-doc
+
+# install specific version of Raspberry firmware and userland tools
+RPI_FIRMWARE_VERSION="1.20190401-1"
+RPI_FIRMWARE_PACKAGES=( raspberrypi-bootloader libraspberrypi0 libraspberrypi-dev libraspberrypi-bin )
+
+for PACKAGE in "${RPI_FIRMWARE_PACKAGES[@]}"
+do
+  wget --quiet "https://archive.raspberrypi.org/debian/pool/main/r/raspberrypi-firmware/${PACKAGE}_${RPI_FIRMWARE_VERSION}_armhf.deb"
+  sudo dpkg -i ${PACKAGE}_${RPI_FIRMWARE_VERSION}_armhf.deb
+  echo "${PACKAGE} hold" | sudo dpkg --set-selections
+  rm ${PACKAGE}_${RPI_FIRMWARE_VERSION}_armhf.deb
+done
+
 # uninstall old network packages
 sudo apt-get purge -y hostapd
 


### PR DESCRIPTION
This installs a specific version of the firmware files. Apart from hosting these files ourselves and having multiple versions in the `Package` file in our repo this is the only way to guarantee a certain version of the firmware files and the accompanying tools is installed for a specific norns update.

I'm not super happy with this solution but I don't think there's an easier way to guarantee a certain version of the firmware files is installed.

Alternatively we could just always install the latest version, in theory newer versions should be backwards compatible, although no promises about that from raspberry.

@artfwo @tehn What do you think?

Fixes #74 
Fixes #66