### PR TITLE
Start norns-matron.service after jack

### DIFF
--- a/config/norns-matron.service
+++ b/config/norns-matron.service
@@ -1,4 +1,6 @@
 [Unit]
+After=norns-jack.service
+Requires=norns-jack.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
If https://github.com/monome/norns/pull/1365 is merged, norns-matron.service has to be updated accordingly, as matron will require a JACK client for system clock reference.