### PR TITLE
start jackd with explicit hw:sndrpimonome device

### DIFF
--- a/config/norns-jack.service
+++ b/config/norns-jack.service
@@ -8,7 +8,7 @@ Group=we
 Environment="JACK_NO_AUDIO_RESERVATION=1"
 LimitRTPRIO=95
 LimitMEMLOCK=infinity
-ExecStart=/usr/bin/jackd -R -P 95 -d alsa -d hw:0 -r 48000 -n 3 -p 128 -S -s
+ExecStart=/usr/bin/jackd -R -P 95 -d alsa -d hw:sndrpimonome -r 48000 -n 3 -p 128 -S -s
 ExecStartPost=/usr/bin/jack_wait -w -t 10
 TimeoutStopSec=1
 


### PR DESCRIPTION
as of the bullseye image if a sufficient number of usb-midi devices are
connected at boot time the codec might not enumerate as the first ALSA
audio card.  when this happens jack startup would fail because `hw:0`
did not correspond to a pcm capable device (or if it did the on board
audio hardware would likely be bypassed)