### PR TITLE
set alsa mixer output by hardware name and store

### DIFF
--- a/scripts/init-norns.sh
+++ b/scripts/init-norns.sh
@@ -13,8 +13,11 @@ sudo i2cset -y 1 0x28 0x40
 sudo i2cset -y 1 0x29 0x00
 sudo i2cset -y 1 0x29 0x40
 
-# unmute soundcard output
+# unmute soundcard output (default device)
 amixer set Master 100% on
+# explicitly set codec output volume
+amixer --device hw:sndrpimonome set Master 100% on
+sudo alsactl store
 
 # enable headphone driver (let matron handle this)
 #sudo i2cset -y 1 0x60 1 192    # enable HP outputs


### PR DESCRIPTION
depending on connected devices the codec may not enumerate as card0 which means it isn't considered the default output device. this change explicitly sets the mixer output level associated with the card (by name) to 100% and stores that setting globally

i'd also recommend running these commands as part of the next update:
```sh
amixer --device hw:sndrpimonome set Master 100% on
sudo alsactl store
```